### PR TITLE
helper object literals and namespaces

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,13 +20,14 @@ const templateManager = require('./template-manager.js');
  */
 module.exports = function createRenderer(options) {
   let opts = Object.assign({
-    cacheExpires:  60,
-    contentTag:    'content',
-    defaultLayout: 'default',
-    environment:   process.env.NODE_ENV,
-    extension:     '.hbs',
-    hbs:           Handlebars.create(),
-    Promise:       Promise
+    cacheExpires:     60,
+    contentTag:       'content',
+    defaultLayout:    'default',
+    environment:       process.env.NODE_ENV,
+    extension:        '.hbs',
+    hbs:              Handlebars.create(),
+    helperNamespaces: false,
+    Promise:          Promise
   }, options);
 
   // Throw errors if required options aren't specified
@@ -46,11 +47,24 @@ module.exports = function createRenderer(options) {
   if (opts.paths.helpers) {
     fs.readdirSync(opts.paths.helpers).filter(file => {
       return path.extname(file) === '.js';
-    }).forEach(helper => {
-      let helperPath = path.join(opts.paths.helpers, helper),
-          name       = path.basename(helper, '.js');
+    }).forEach(helperFile => {
+      let helperPath = path.join(opts.paths.helpers, helperFile),
+          name       = path.basename(helperFile, '.js');
 
-      opts.hbs.registerHelper(name, require(helperPath));
+      const helperData = require(helperPath);
+      if (typeof helperData === 'function') {
+        opts.hbs.registerHelper(name, require(helperPath));
+      } else if (typeof helperData === 'object') {
+        // support for object literals containing multiple files (and namespaces by file name)
+        Object.keys(helperData).forEach(key => {
+          if (helperData[key] !== undefined) {
+            opts.hbs.registerHelper(
+              opts.helperNamespaces
+                ? `${name}_${key}`
+                : key, helperData[Key]);
+          }
+        });
+      } else throw new Error(`helper file: ${name} contains invalid type`);
     });
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -56,12 +56,12 @@ module.exports = function createRenderer(options) {
         opts.hbs.registerHelper(name, require(helperPath));
       } else if (typeof helperData === 'object') {
         // support for object literals containing multiple files (and namespaces by file name)
-        Object.keys(helperData).forEach(key => {
+        Object.keys(helperData).forEach((key) => {
           if (helperData[key] !== undefined) {
             opts.hbs.registerHelper(
               opts.helperNamespaces
                 ? `${name}_${key}`
-                : key, helperData[Key]);
+                : key, helperData[key]);
           }
         });
       } else throw new Error(`helper file: ${name} contains invalid type`);


### PR DESCRIPTION
Hi Connor, thanks for this project. Since I'm used to Grails' gsp support for namespacing and multiple custom tags in one file I thought i'd add a couple changes: 
- added support for helper files to be object literals containing 1 or more functions
- added optional support with object literals to use their respective filenames as namespaces

this means you can have a helper file that looks as below: 

`.../helpers/eg.js`
```javascript
module.exports = {
  doSomething: (text) => { return `${text} says OOOH` },
  doSomethingElse: (text) => { return `${text} says AAAH` } 
}
```
thus:
`myImportantWebPage.hbs`
```
{{doSomething Fred}}
{{doSomethingElse Sally}}
```
or if the following is set in options
`helperNamespaces: true,`
```
{{eg_doSomething Fred}}
{{eg_doSomethingElse Sally}}
```
I'm afraid I'm woefully unfamiliar with your unit tester and it didn't want to run on my machine.  I've functionally demonstrated that it works on a build i'm working on however and, given it's all of 5 lines of code... 

